### PR TITLE
Add canonical pointer to wiki

### DIFF
--- a/src/developing/modifying-install-image-packages.md
+++ b/src/developing/modifying-install-image-packages.md
@@ -3,7 +3,8 @@ date: 2022-07-09
 title: "Modifying install images"
 tags: ["alpine","docs","linux","devel"]
 series: ["docs4web"]
-pageCanonical: false
+notCanonical: true
+toCanonical: https://wiki.alpinelinux.org/wiki/Testing_modified_install_images_and_packages
 ---
 
 # Modifying install images

--- a/src/howtos/netboot-alpine-linux-using-ipxe.md
+++ b/src/howtos/netboot-alpine-linux-using-ipxe.md
@@ -3,7 +3,8 @@ date: 2022-07-09
 title: "Netboot Alpine Linux using iPXE"
 tags: ["alpine","howtos","docs","linux","sysadmin-devops"]
 series: ["docs4web","alpine-linux-local-server"]
-pageCanonical: false
+notCanonical: true
+toCanonical: https://wiki.alpinelinux.org/wiki/Netboot_Alpine_Linux_using_iPXE
 ---
 
 # Netboot Alpine Linux using iPXE


### PR DESCRIPTION
The two new pages are already on the Alpine Wiki, so point to the Wiki pages as canonical

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>